### PR TITLE
fix(css): fix some icons' color when theme is dark

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -87,13 +87,13 @@
 
 .icon-sharereview-password {
     background-image: url(../img/password.svg);
-    /*filter: var(--background-invert-if-dark);*/
+    filter: var(--background-invert-if-dark);
     background-size: 16px;
 }
 
 .icon-sharereview-calendar {
     background-image: url(../img/calendar.svg);
-    /*filter: var(--background-invert-if-dark);*/
+    filter: var(--background-invert-if-dark);
     background-size: 16px;
 }
 


### PR DESCRIPTION
Please check my commit.

**⚠️ Not tested (no test environment).**

@Rello, can you explain why this was commented ? (same for many others as well) : 

`filter: var(--background-invert-if-dark);`